### PR TITLE
Ruby pdf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,5 @@
 /tmp
 /jetty
 /.idea
+/public/pdfs/*.pdf
 .keep

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,9 @@ gem 'jbuilder', '~> 2.0'
 gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'high_voltage', '~> 2.3.0'
 
+gem 'wicked_pdf'
+gem 'wkhtmltopdf-binary'
+
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,6 +194,9 @@ GEM
       json (>= 1.8.0)
     warden (1.2.3)
       rack (>= 1.0)
+    wicked_pdf (0.11.0)
+      rails
+    wkhtmltopdf-binary (0.9.9.3)
 
 PLATFORMS
   ruby
@@ -221,3 +224,5 @@ DEPENDENCIES
   turbolinks
   tzinfo-data
   uglifier (>= 1.3.0)
+  wicked_pdf
+  wkhtmltopdf-binary

--- a/app/assets/stylesheets/pdf.css
+++ b/app/assets/stylesheets/pdf.css
@@ -1,0 +1,10 @@
+/**
+* This file is just a placeholder to demonstrate how pdf content can be .
+* See https://github.com/mileszs/wicked_pdf for more details.
+*/
+
+
+body {
+    color: black;
+    font-family: Georgia, serif;
+}

--- a/app/assets/stylesheets/pdf.css
+++ b/app/assets/stylesheets/pdf.css
@@ -4,7 +4,7 @@
 */
 
 
-body {
+.pdf_content {
     color: black;
     font-family: Georgia, serif;
 }

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -132,6 +132,33 @@ class CatalogController < ApplicationController
     config.add_show_field 'published_place_ssi', :label => 'Udgivelsessted'
 
 
+    # Overwriting this method to enable pdf generation using WickedPDF
+    # Unfortunately the additional_export_formats method was quite difficult t
+    # to use for this use case.
+    def show
+      @response, @document = fetch params[:id]
+
+      name = @document['work_title_tesim'].first.strip rescue @document.id
+      path = Rails.root.join('public', 'pdfs', "#{@document.id.gsub('/', '_')}.pdf")
+
+      respond_to do |format|
+        format.html { setup_next_and_previous_documents }
+        format.json { render json: { response: { document: @document } } }
+        format.pdf do
+          # if we've already created the file, no need to regenerate it
+          if File.exist? path.to_s
+            send_file path.to_s, type: 'application/pdf', disposition: :inline
+          else
+            render pdf: name, footer: { right: '[page] af [topage] sider' },
+                   save_to_file: path
+          end
+        end
+
+        additional_export_formats(@document, format)
+      end
+    end
+
+
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,21 +24,7 @@ module ApplicationHelper
     published.html_safe
   end
 
-  def render_snippet(id,op=nil)
-    a =id.split("#")
-    uri = "#{Rails.application.config_for(:adl)["snippet_server_url"]}?doc=#{a[0]}.xml"
-    uri += "&id=#{a[1]}" unless a.size < 2
-    uri += "&op=#{op}" unless op.nil?
-    logger.debug("url "+uri)
-    res = Net::HTTP.get_response(URI(uri))
-    result = ''
-    if (res.code == "200")
-      result = res.body
-    else
-      result ="<div class='error'>Unable to connect to snippet server #{uri}</div>"
-    end
-    result.html_safe.force_encoding('UTF-8')
-  end
+
 
   def present_snippets args
     val = args[:value]

--- a/app/models/file_server.rb
+++ b/app/models/file_server.rb
@@ -1,0 +1,17 @@
+# Class to centralise inteface with FileServer
+class FileServer
+  def self.render_snippet(id,op=nil)
+    a =id.split("#")
+    uri = "#{Rails.application.config_for(:adl)["snippet_server_url"]}?doc=#{a[0]}.xml"
+    uri += "&id=#{a[1]}" unless a.size < 2
+    uri += "&op=#{op}" unless op.nil?
+    Rails.logger.debug("url #{uri}")
+    res = Net::HTTP.get_response(URI(uri))
+    if (res.code == "200")
+      result = res.body
+    else
+      result ="<div class='error'>Unable to connect to snippet server #{uri}</div>"
+    end
+    result.html_safe.force_encoding('UTF-8')
+  end
+end

--- a/app/views/catalog/_show_header_work.html.erb
+++ b/app/views/catalog/_show_header_work.html.erb
@@ -8,3 +8,4 @@
       <% end -%>
   <% end -%>
 </dl>
+<%= link_to 'Download som PDF', solr_document_path(document, format: :pdf ) %>

--- a/app/views/catalog/_show_work.html.erb
+++ b/app/views/catalog/_show_work.html.erb
@@ -1,6 +1,6 @@
 <%# default partial to display solr document fields in catalog show view -%>
 <div class="text-content">
   <div class="text">
-    <%= render_snippet(document[:id]) %>
+    <%= FileServer.render_snippet(document[:id]) %>
   </div>
 </div>

--- a/app/views/catalog/show.pdf.erb
+++ b/app/views/catalog/show.pdf.erb
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset='utf-8'/>
+  <%= wicked_pdf_stylesheet_link_tag "pdf" -%>
+  <%= wicked_pdf_javascript_include_tag "number_pages" %>
+</head>
+<body>
+<div id="header">
+  <%#= wicked_pdf_image_tag 'logo.png' %>
+</div>
+<div id="content">
+  <%= FileServer.render_snippet(@document.id) %>
+</div>
+</body>
+</html>

--- a/app/views/catalog/show.pdf.erb
+++ b/app/views/catalog/show.pdf.erb
@@ -9,7 +9,7 @@
 <div id="header">
   <%#= wicked_pdf_image_tag 'logo.png' %>
 </div>
-<div id="content">
+<div id="pdf_content">
   <%= FileServer.render_snippet(@document.id) %>
 </div>
 </body>

--- a/config/initializers/wicked_pdf.rb
+++ b/config/initializers/wicked_pdf.rb
@@ -1,0 +1,5 @@
+executable = `which wkhtmltopdf`.chomp
+fail 'ERROR: wkhtmltopdf must be installed to run ADL!!' unless executable.size > 0
+WickedPdf.config = {
+  :exe_path => executable
+}


### PR DESCRIPTION
The jsPDF was incapable of handling really large files so I've opted for a server side solution instead using [wicked pdf](https://github.com/mileszs/wicked_pdf). The logic saves files after generating them and does not regenerate them if an existing file is found, thus limiting server load over time. Note however that this means that change to the TEI won't automatically be reflected in the PDFs. I'm not quite sure what the best solution for this is.
