### PR TITLE
Tabs in fixed header

### DIFF
--- a/app/assets/javascripts/catalog.js
+++ b/app/assets/javascripts/catalog.js
@@ -109,6 +109,23 @@ $(document).ready(function(){
                 return firstVisibleElement;
             },
 
+            getCurrentPageId: function () {
+                var currentPageIndex,
+                    firstVisibleElement = this.getFirstVisibleElement();
+                if (firstVisibleElement) {
+                    var firstVisibleElementTopPosition = $(firstVisibleElement).position().top,
+                        allPageBreaks = $('.pageBreak');
+                    allPageBreaks.each(function (index, elem) {
+                        if ($(elem).position().top > firstVisibleElementTopPosition) {
+                            currentPageIndex = index - 1; // last page that has not been scrolled out of yet
+                            return false;
+                        }
+                    });
+                    return $(allPageBreaks[currentPageIndex]).attr('id');
+                }
+                return; // no first page was found
+            },
+
             getFirstVisiblePage: function () {
                 var firstVisibleElement = this.getFirstVisibleElement();
                 if (firstVisibleElement.tagName === 'P' || firstVisibleElement.tagName === 'DIV') {
@@ -209,6 +226,13 @@ $(document).ready(function(){
     // also test the scrollTop from loading (if the page starts scrolled)
     ADL.scrollSniffer();
 
+    // clicks on nav-tab-instance should correct for scrolling page!
+    $('.nav-tab-instance').click(function (e) {
+        var pageId = ADL.getCurrentPageId();
+        if (pageId && e.target.tagName === 'A') {
+            $(e.target).attr('href', $(e.target).attr('href') + '#' + pageId);
+        }
+    });
     // modal should be closed as soon as one clicks on a in-page link.
     $('.modal-body').click(function (e) {
         if (e.target.tagName === 'A' && ((e.target.href.indexOf('#idm') > 0) || (e.target.href.indexOf('#workid') > 0))) {

--- a/app/assets/javascripts/catalog.js
+++ b/app/assets/javascripts/catalog.js
@@ -159,16 +159,16 @@ $(document).ready(function(){
 
                 // FIXME: Set a class instead, and let the stylesheets do the CSS work!
                 if ($(window).scrollTop() >= 55) {
-                    $('.workNavbarFixContainer, .workHeaderFixContainer').addClass('fixed');
+                    $('.workContent').addClass('fixedHeader');
                     $('.workHeader dl').hide();
-                    $('.nav-tab-instance').addClass('fixedTop');
+                    $('.workNavbarFixContainer, .workHeaderFixContainer, .nav-tab-instance-fixContainer').addClass('fixed');
                     //correct top for all content (to correct top point just under the fixed top bars)
                     $('#content .workContent div, #content .workContent p').removeClass('top1cor').addClass('top2cor');
 
                 } else {
-                    $('.workNavbarFixContainer, .workHeaderFixContainer').removeClass('fixed');
+                    $('.workNavbarFixContainer, .workHeaderFixContainer, .nav-tab-instance-fixContainer').removeClass('fixed');
+                    $('.workContent').removeClass('fixedHeader');
                     $('.workHeader dl').show();
-                    $('.nav-tab-instance').removeClass('fixedTop');
                     //correct top for all content (to correct top point just under the fixed top bars)
                     $('#content .workContent div, #content .workContent p').removeClass('top2cor').addClass('top1cor');
 

--- a/app/assets/stylesheets/adl/navbar.scss
+++ b/app/assets/stylesheets/adl/navbar.scss
@@ -23,32 +23,39 @@
   visibility: hidden;
 }
 
-// We (mis)use the .nav-tab-instance to fill out the gapping space when we reduce the header size when fixing it.
-// By hiding (but not taking it out of the flow!) this bar and give it a huge height, the content wont jump upwards when
-// scrolling down the page and doing the header fixing thing. It's a bit strange hack, but it works!
-.nav-tab-instance.fixedTop{
-  visibility:visible;
-  height:auto;
-}
-.nav-tab-instance.fixedTop{
-  visibility:hidden;
-  height:159px; // This is the acummulated height of the bars we position fix, and the elements we hide.
+.workContent.fixedHeader{
+  padding-top:200px; // Our fixed headers height - content should be moved down
 }
 
+// text/faksimile tab bar
+.nav-tab-instance-fixContainer.fixed{ // FIXME: This is not following the nameconvention in the rest of the elements!
+  position:fixed;
+  top:152px;
+  right:0;
+  left:0;
+  z-index:10;
+  padding-bottom: 10px;
+}
+
+// navbar
 .workNavbarFixContainer.fixed{
-    position: fixed;
-    top: 50px;
-    right: 0;
-    left: 0;
-    background-color: #fff;
+  position: fixed;
+  top: 50px;
+  right: 0;
+  left: 0;
+  background-color: #fff;
+  z-index:10;
 }
 
+// header (titlebar)
 .workHeaderFixContainer.fixed{
-    position: fixed;
-    top: 82px;
-    right: 0;
-    left: 0;
-    padding-bottom: 10px;
+  position: fixed;
+  top: 82px;
+  right: 0;
+  left: 0;
+  padding-bottom: 10px;
+  background-color: white;
+  z-index:10;
 }
 
 body.modal-open .workNavbarFixContainer.fixed, body.modal-open .workHeaderFixContainer.fixed, body.modal-open .navbar-fixed-top{

--- a/app/views/catalog/_show_work.html.erb
+++ b/app/views/catalog/_show_work.html.erb
@@ -2,7 +2,8 @@
 
 <% document_empty  = @document_empty || !FileServer.has_text(document.id) %>
 
- <div class="container">
+ <div class="container nav-tab-instance-fixContainer">
+   <div class="row"><div class="col-md-12">
     <div class="nav-tab-instance">
       <ul class="nav nav-tabs">
         <li role="presentation" class="active">
@@ -19,20 +20,26 @@
           <% end %>
         </li>
       </ul>
+      </div></div>
     </div>
-
-<% if !document_empty %>
-    <div class="text-content workContent">
-      <div class="text">
-        <% text ||= FileServer.render_snippet(document.id) %>
-        <%= text.html_safe %>
-      </div>
-    </div>
-<% else %>
-    <div class="text-content workContent">
-      <div class="text">
-      <%= t '.no_text' %>
-      </div>
-    </div>
-<% end %>
  </div>
+<div class="container">
+  <div class="row">
+    <div class="col-md-12">
+      <% if !document_empty %>
+          <div class="text-content workContent">
+            <div class="text">
+              <% text ||= FileServer.render_snippet(document.id) %>
+              <%= text.html_safe %>
+            </div>
+          </div>
+      <% else %>
+          <div class="text-content workContent">
+            <div class="text">
+            <%= t '.no_text' %>
+            </div>
+          </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/catalog/facsimile.html.erb
+++ b/app/views/catalog/facsimile.html.erb
@@ -5,26 +5,37 @@
         <%= render partial: 'previous_next_doc' %>
         <%= render partial: 'catalog/show_header_work' %>
 
-        <div class="container">
-            <div class="nav-tab-instance">
-                <ul class="nav nav-tabs">
-                  <li role="presentation">
-                    <%= link_to(solr_document_path(document), disabled: document_empty) do %>
-                        <%= bootstrap_glyphicon 'font' %>
-                        Tekst
-                    <% end %>
-                  </li>
-                  <li role="presentation" class="active">
-                    <%# Note we need to use no_turbolink because turbolinks will fuck with the unveil library %>
-                    <%= link_to(facsimile_catalog_path(document.id), data: { no_turbolink: true }) do %>
-                        <%= bootstrap_glyphicon 'picture' %>
-                        Faksimile
-                    <% end %>
-                  </li>
-                </ul>
+        <div class="container nav-tab-instance-fixContainer">
+          <div class="row">
+            <div class="col-md-12">
+                <div class="nav-tab-instance">
+                    <ul class="nav nav-tabs">
+                      <li role="presentation">
+                        <%= link_to(solr_document_path(document), disabled: document_empty) do %>
+                            <%= bootstrap_glyphicon 'font' %>
+                            Tekst
+                        <% end %>
+                      </li>
+                      <li role="presentation" class="active">
+                        <%# Note we need to use no_turbolink because turbolinks will fuck with the unveil library %>
+                        <%= link_to(facsimile_catalog_path(document.id), data: { no_turbolink: true }) do %>
+                            <%= bootstrap_glyphicon 'picture' %>
+                            Faksimile
+                        <% end %>
+                      </li>
+                    </ul>
+                </div>
             </div>
-            <%= FileServer.facsimile(@document.id).html_safe %>
           </div>
+        </div>
+        <div class="container">
+            <div class="row">
+                <div class="col-md-12">
+                    <%= FileServer.facsimile(@document.id).html_safe %>
+                </div>
+            </div>
+        </div>
+
       </div>
 
 


### PR DESCRIPTION
@davidgrove73 @tja1607 

Jeg har puttet text/faksimili tabs'ene op i den fixed header nu, så de er tilgængelige uanset hvor man er på siden. Det krævede en del omstrukturering, da content var i tabs containeren (og det var også det som har givet os problemer med footeren på smalle skærme. Nu stopper jeg bare footeren om bag den fixed header hvis den kommer for højt op - det ser ikke sexet ud, men det ligner heller ikke en fejl længere!)

Faksimili tab'en klikker nu direkte ind på den første side som er synlig (ikke korrigeret for hvis den er under den fixed header, så en gang imellem ligner det siden inden). Før linkede den bare til toppen, og det virkede i hvert fald dumt!

Der er stadig problemer med faksimili siden - index virker ikke fordi den ikke er tagget ordentlig op (og det er noget skidt), og det medfører også at jeg ikke kan linke til andet end toppen af teksten, hvis man klikker fra faksimili til tekst (og det er også skidt).

Jeg har ikke gennemtestet noget overhovedet, men jeg har 3 unger der er alene hjemme, og venter på mig, så nu smutter jeg også på weekend! Lad være med at merge, med mindre I er sikre på at det er ok! Jeg garanterer på ingen måde at jeg ikke har introduceret fejl i markup'en med denne "feber-redning"
