### PR TITLE
Text facimile swapping

### DIFF
--- a/app/assets/javascripts/catalog.js
+++ b/app/assets/javascripts/catalog.js
@@ -277,7 +277,7 @@ $(document).ready(function(){
     $('.nav-tab-instance').click(function (e) {
         var pageId = ADL.getCurrentPageId();
         if (pageId && e.target.tagName === 'A') {
-            $(e.target).attr('href', $(e.target).attr('href') + '#' + pageId);
+            $(e.target).attr('href', $(e.target).attr('href') + '/#' + pageId);
         }
     });
     // modal should be closed as soon as one clicks on a in-page link.

--- a/app/assets/javascripts/catalog.js
+++ b/app/assets/javascripts/catalog.js
@@ -243,19 +243,14 @@ $(document).ready(function(){
 
                 // FIXME: Set a class instead, and let the stylesheets do the CSS work!
                 if ($(window).scrollTop() >= 55) {
-                    $('.workContent').addClass('fixedHeader');
-                    $('.workHeader dl').hide();
-                    $('.workNavbarFixContainer, .workHeaderFixContainer, .nav-tab-instance-fixContainer').addClass('fixed');
-                    //correct top for all content (to correct top point just under the fixed top bars)
-                    $('#content .workContent div, #content .workContent p').removeClass('top1cor').addClass('top2cor');
+                    $('body').addClass('fixedHeader');
+                    $('.workHeader dl').slideUp(200); // We have a minor animation to let users subliminal understand that we are collapsing the header
+                    $('#content .snippetRoot div, #content .snippetRoot p, #content .snippetRoot .pageBreak, #content .snippetRoot img').removeClass('top1cor').addClass('top2cor');
 
                 } else {
-                    $('.workNavbarFixContainer, .workHeaderFixContainer, .nav-tab-instance-fixContainer').removeClass('fixed');
-                    $('.workContent').removeClass('fixedHeader');
-                    $('.workHeader dl').show();
-                    //correct top for all content (to correct top point just under the fixed top bars)
-                    $('#content .workContent div, #content .workContent p').removeClass('top2cor').addClass('top1cor');
-
+                    $('body').removeClass('fixedHeader');
+                    $('.workHeader dl').slideDown(200);
+                    $('#content .snippetRoot div, #content .snippetRoot p, #content .snippetRoot .pageBreak, #content .snippetRoot img').removeClass('top2cor').addClass('top1cor');
                 }
             },
 

--- a/app/assets/javascripts/catalog.js
+++ b/app/assets/javascripts/catalog.js
@@ -2,10 +2,6 @@
  * Created by romc on 7/8/15.
  */
 
-$(document).ready(function(){
-    resizeDiv();
-});
-
 window.onresize = function(event) {
     resizeDiv();
 }
@@ -206,6 +202,8 @@ $(document).ready(function(){
             }
         };
     } (window, jQuery);
+
+    resizeDiv();
 
     $(document).ajaxComplete(function (e, xhr, options) {
         if (options && options.url && options.url.indexOf('/feedback?') >= 0) { // FIXME: Is this really the best way to pick out the feedback responses?

--- a/app/assets/javascripts/catalog.js
+++ b/app/assets/javascripts/catalog.js
@@ -135,6 +135,9 @@ $(document).ready(function(){
              * @returns {number | HTMLElement}
              */
             getPageNumber: function(getElem) { // XXX XXX XXX This is the one that actually works!
+                if (!ADL.PAGETOPPOSITIONS.length) {
+                    return 0; // If there is no pagebreaks just return 0;
+                }
                 // noget med document.offset.y eller noget, og sammenligne det med PAGETOPPOSITIONS
                 var scrollTop = $(window).scrollTop();
 //                ADL.youAreHere = (scrollTop > 55) ? scrollTop - 18 : scrollTop; // magic number 188 = correcting for fixed headers 50 + 32 + 106 (-110 for only gd know why :( )

--- a/app/assets/javascripts/catalog.js
+++ b/app/assets/javascripts/catalog.js
@@ -119,6 +119,7 @@ $(document).ready(function(){
     // FIXME: We should wrap all our functions into this object, in order not to polute the global object!
     window.ADL = function (window, $, undefined) {
         return {
+            test : false, // remove this to get rid of all kinds of test outputs (the pagenumber in bottom right so far)!
             youAreHere: 0,
 
             PAGETOPPOSITIONS: getPagePositions(), // This is going to be recalculated in ½ sec. but there has to be some values for the first page calculations!
@@ -233,6 +234,16 @@ $(document).ready(function(){
 
             scrollSniffer: function (e) {
                 // ADL.updateBookmarkLink(e); // FIXME: This shall be incommented if bookmarks should be per paragraph
+
+                // Add pagenumber bottom right if test
+                if (ADL.test) {
+                    var pageNumber = $('.showPage');
+                    if (!pageNumber.length) {
+                        pageNumber = $('<div class="showPage" style="position:fixed;z-index:100000;background-color:#fff;color:#000;text-align:center;padding-top:8px;height:32px;min-width:32px;bottom:10px;right:10px;border-radius:5px;border:2px solid #000"></div>');
+                        pageNumber.appendTo('body');
+                    }
+                    $('.showPage').text(ADL.getPageNumber());
+                }
 
                 // FIXME: Set a class instead, and let the stylesheets do the CSS work!
                 if ($(window).scrollTop() >= 55) {

--- a/app/assets/javascripts/catalog.js
+++ b/app/assets/javascripts/catalog.js
@@ -92,7 +92,6 @@ $(document).ready(function(){
     }
 
     // --- private helper functions ---
-
     var getHeightOfFixedHeaders = function () {
         var fixedHeaders = $('.fixed, .navbar-fixed-top'),
             allFixedHeaderHeight = 0;
@@ -123,8 +122,6 @@ $(document).ready(function(){
             youAreHere: 0,
 
             PAGETOPPOSITIONS: getPagePositions(), // This is going to be recalculated in ½ sec. but there has to be some values for the first page calculations!
-
-//            getPagePositions: getPagePositions, // We need to recalculate all page positions after the initial load, because they get outdated after a while
 
             recalculatePageTopPositions: function () {
                 this.PAGETOPPOSITIONS = getPagePositions();

--- a/app/assets/javascripts/catalog.js
+++ b/app/assets/javascripts/catalog.js
@@ -106,8 +106,9 @@ $(document).ready(function(){
         var allFixedHeaderHeight = getHeightOfFixedHeaders();
         return $('.pageBreak, .snippetRoot').map(function (index, pageBreakElem) {
             pageBreakElem = (pageBreakElem.id) ? pageBreakElem : $(pageBreakElem).parent()[0]; // FIXME: This would not be needed if Sigge also id tagged pageBreaks on faksimili pages!
+            pageId = $(pageBreakElem).attr('id');
             return {
-                page: $(pageBreakElem).attr('id').substr(1),
+                page: /^s\d+$/.test(pageId) ? pageId.substr(1) : pageId,
                 topPos: $(pageBreakElem).position().top,
                 topPosFixed: $(pageBreakElem).position().top + allFixedHeaderHeight - 50, // magic number 50 is to give it a little margin. If the first page only have a few pixels showing, the reader IS on the next page!
                 elem: pageBreakElem

--- a/app/assets/javascripts/catalog.js
+++ b/app/assets/javascripts/catalog.js
@@ -294,7 +294,7 @@ $(document).ready(function(){
     // setup scrollsniffer
     $(window).scroll(ADL.scrollSniffer);
     // also test the scrollTop from loading (if the page starts scrolled)
-    ADL.scrollSniffer();
+    setTimeout(ADL.scrollSniffer, 1000); // start fetching the pagenumber once after load.
 
     // clicks on nav-tab-instance should correct for scrolling page!
     $('.nav-tab-instance').click(function (e) {

--- a/app/assets/javascripts/catalog.js
+++ b/app/assets/javascripts/catalog.js
@@ -310,6 +310,31 @@ $(document).ready(function(){
     setTimeout(function () { ADL.PAGETOPPOSITIONS = getPagePositions(); }, 500); // recalculate pageBreak table a couple of times because they changes after a while
     setTimeout(function () { ADL.PAGETOPPOSITIONS = getPagePositions(); }, 1000);// and it differs a bit from browser to browser how long it takes to have the right numbers
     setTimeout(function () { ADL.PAGETOPPOSITIONS = getPagePositions(); }, 2000);
+
+/*
+    if ($('.facsimile').length) { // This is a facsimile page - do the dirty previousPage thingie! :6 (ask Sigge if you don't know why this is!)
+        $('#tableOfContent').closest('.modal-content').find('.modal-body').click(function (e) {
+            if (e.target.tagName === 'A') {
+                e.preventDefault(); // Hijacking the event completely! :/ FIXME: This is definitely not the right way to do this - it ought to be pointing at the correct page from the server response to begin with!
+console.log('===========\nHijacking a click event ('+ $(e.target).attr('href')+')');
+                var elementHref = $(e.target).attr('href'),
+                    element = $(elementHref);
+                var elementToScrollTo = element;
+                if (element.prev() && element.prev().attr('id')) {
+                    elementToScrollTo = element.prev();
+                    console.log('fetching prev sibling ('+elementToScrollTo.attr('id')+')...');
+                    if (elementToScrollTo.children().length && elementToScrollTo.children().last() && elementToScrollTo.children().last().attr('id')) {
+                        elementToScrollTo = elementToScrollTo.children().last();
+                        console.log('fetching last child of prev sibling ('+elementToScrollTo.attr('id')+')...');
+                    }
+                }
+console.log('scrolling to the element...');
+                $(window).scrollTop(elementToScrollTo.offset().top);
+
+            }
+        });
+    }
+*/
 });
 
 function cookieTerms(cname, cvalue, exdays) {

--- a/app/assets/javascripts/catalog.js
+++ b/app/assets/javascripts/catalog.js
@@ -130,6 +130,9 @@ $(document).ready(function(){
             pageType: (function () {
                 var snippetRoot = $('.snippetRoot');
                 if (snippetRoot.hasClass('facsimile')) {
+                    // This only gets executed on facsimile pages
+                    $('.workNavBar button.contentSearch').attr('disabled', true); // disable page search
+
                     return 'facsimile';
                 }
                 if (snippetRoot.hasClass('text')) {

--- a/app/assets/javascripts/catalog.js
+++ b/app/assets/javascripts/catalog.js
@@ -149,8 +149,7 @@ $(document).ready(function(){
                 }
                 // noget med document.offset.y eller noget, og sammenligne det med PAGETOPPOSITIONS
                 var scrollTop = $(window).scrollTop();
-//                ADL.youAreHere = (scrollTop > 55) ? scrollTop - 18 : scrollTop; // magic number 188 = correcting for fixed headers 50 + 32 + 106 (-110 for only gd know why :( )
-                ADL.youAreHere = scrollTop + 198; // magic number 188 = correcting for fixed headers 50 + 32 + 106 (-110 for only gd know why :( ) // XXX XXX FIXME: is 198 necessary here??
+                ADL.youAreHere = (scrollTop > 55) ? scrollTop + 88 : scrollTop; // magic number 188 = correcting for fixed headers 50 + 32 + 106 (-100 for only God know why :( )
                 var firstVisiblePage = 1,
                     i = 0;
                 while(ADL.youAreHere > ADL.PAGETOPPOSITIONS[i].topPosFixed) {

--- a/app/assets/javascripts/catalog.js
+++ b/app/assets/javascripts/catalog.js
@@ -129,6 +129,17 @@ $(document).ready(function(){
                 this.PAGETOPPOSITIONS = getPagePositions();
             },
 
+            pageType: (function () {
+                var snippetRoot = $('.snippetRoot');
+                if (snippetRoot.hasClass('facsimile')) {
+                    return 'facsimile';
+                }
+                if (snippetRoot.hasClass('text')) {
+                    return 'text';
+                }
+                return 'other';
+            })(),
+
             /**
              * Get the page number of the first visible page (or the pagebreak element itself)
              * @param getElem {boolean} Optional If set the method returns the HTMLElement of the pagebreak, else it returns the pagenumber

--- a/app/assets/stylesheets/adl.css.scss
+++ b/app/assets/stylesheets/adl.css.scss
@@ -1,3 +1,6 @@
+* {
+  box-sizing:border-box;
+}
 
 
 /* ADL Variables for overwriting bootstrap

--- a/app/assets/stylesheets/adl/navbar.scss
+++ b/app/assets/stylesheets/adl/navbar.scss
@@ -8,27 +8,28 @@
 // Fix for in-page linking in a page with a fixed header.
 // Solution nicked from https://github.com/twbs/bootstrap/issues/1768
 // FIXME: I don't think pseudo-selectors are working in ios safari? Have this tested on an iPhone!
-#content .top1cor:before{ // Correcting for the top bar
+body.fixedHeader #content .snippetRoot .top1cor:before{ // Correcting for the top bar
   display: block;
   content: " ";
   margin-top: -50px;
   height: 50px;
   visibility: hidden;
 }
-#content .top2cor:before{ // Correcting for the top bar, the tool bar and the fixed header
-  display: block;
-  content: " ";
-  margin-top: -191px;
-  height: 191px;
-  visibility: hidden;
-}
+body.fixedHeader #content .snippetRoot .top2cor:before{ // Correcting for the top bar, the tool bar and the fixed header
+   display: block;
+   content: " ";
+   margin-top: -195px;
+   height: 195px;
+   visibility: hidden;
+ }
 
-.workContent.fixedHeader{
-  padding-top:200px; // Our fixed headers height - content should be moved down
+
+body.fixedHeader .workContent{
+  padding-top:188px; //400px; // Our fixed headers height - content should be moved down
 }
 
 // text/faksimile tab bar
-.nav-tab-instance-fixContainer.fixed{ // FIXME: This is not following the nameconvention in the rest of the elements!
+body.fixedHeader .nav-tab-instance-fixContainer{ // FIXME: This is not following the nameconvention in the rest of the elements!
   position:fixed;
   top:152px;
   right:0;
@@ -38,7 +39,7 @@
 }
 
 // navbar
-.workNavbarFixContainer.fixed{
+body.fixedHeader .workNavbarFixContainer{
   position: fixed;
   top: 50px;
   right: 0;
@@ -48,7 +49,7 @@
 }
 
 // header (titlebar)
-.workHeaderFixContainer.fixed{
+body.fixedHeader .workHeaderFixContainer{
   position: fixed;
   top: 82px;
   right: 0;
@@ -58,6 +59,6 @@
   z-index:10;
 }
 
-body.modal-open .workNavbarFixContainer.fixed, body.modal-open .workHeaderFixContainer.fixed, body.modal-open .navbar-fixed-top{
+body.fixedHeader.modal-open .workNavbarFixContainer, body.fixedHeader.modal-open .workHeaderFixContainer, body.fixedHeader.modal-open .navbar-fixed-top{
     right:15px;
 }


### PR DESCRIPTION
@davidgrove73 @siglun 
This is fixing the swapping between text and facimile, staying on (aprox.) same page, and also the stuff hiding behind the fixed headers. I am not sure if it covers 100% of the cases, but at least it is way better than what is in there right now.

I am pulling it into master now, because Sigge could benefit from seeing what pages index links are actually pointing at in the html (mostly in the facsimile page) unless we deside to go for the less ambitious dimming-the-options-on-the-facsimile-page solution.
