### PR TITLE
Remove turbolinks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,8 +18,8 @@ gem 'jquery-rails'
 gem 'blacklight', '~> 6.0'
 gem 'tzinfo-data', platforms: [:mingw, :mswin]
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
-gem 'turbolinks'
-gem 'jquery-turbolinks'
+#gem 'turbolinks'
+#gem 'jquery-turbolinks'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,9 +116,6 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    jquery-turbolinks (2.1.0)
-      railties (>= 3.1.0)
-      turbolinks
     json (1.8.3)
     kaminari (0.17.0)
       actionpack (>= 3.0.0)
@@ -210,9 +207,6 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
-    turbolinks (5.0.1)
-      turbolinks-source (~> 5)
-    turbolinks-source (5.0.0)
     twitter-typeahead-rails (0.11.1.pre.corejavascript)
       actionpack (>= 3.1)
       jquery-rails
@@ -246,7 +240,6 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jettywrapper (>= 2.0)
   jquery-rails
-  jquery-turbolinks
   kbcookie (>= 0.0.0)!
   oai
   rails (= 4.2.6)
@@ -256,7 +249,6 @@ DEPENDENCIES
   spring
   sqlite3
   therubyracer
-  turbolinks
   tzinfo-data
   uglifier (>= 1.3.0)
   wicked_pdf

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,10 +14,8 @@
 //= require jquery_ujs
 //= require jquery.unveil.min
 //= require jquery.visible.min
-//= require jquery.turbolinks
 //= require bootstrap/tab
 // Required by blacklight
 //= require blacklight/blacklight
-//= require turbolinks
 
 //= require_tree .

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -49,7 +49,7 @@ module ApplicationHelper
   end
 
   def search_type_link(type, label)
-    link_to label, '#', data: { search_type: type,  no_turbolink: true }
+    link_to label, '#', data: { search_type: type}
   end
 
   # Generic method to create glyphicon icons

--- a/app/views/catalog/_bookmark_control.html.erb
+++ b/app/views/catalog/_bookmark_control.html.erb
@@ -7,14 +7,12 @@
   <% unless bookmarked? document %>
 
       <%= form_tag( bookmark_path( document ), :method => :put, :class => "bookmark_toggle", "data-doc-id" => document.id, :'data-present' => t('blacklight.search.bookmarks.present'), :'data-absent' => t('blacklight.search.bookmarks.absent'), :'data-inprogress' => t('blacklight.search.bookmarks.inprogress')) do %>
-            <label for=<%= "bookmark_toggle_#{document.id.to_s.parameterize}" %> class="bookmark_add_label"><h4><span class="glyphicon glyphicon-bookmark"></span></h4></label>
             <%= submit_tag(t('blacklight.bookmarks.add.button'), :id => "bookmark_toggle_#{document.id.to_s.parameterize}", :class => "bookmark_add btn btn-default") %>
       <% end %>
 
   <% else %>
 
       <%= form_tag( bookmark_path( document ), :method => :delete, :class => "bookmark_toggle", "data-doc-id" => document.id, :'data-present' => t('blacklight.search.bookmarks.present'), :'data-absent' => t('blacklight.search.bookmarks.absent'), :'data-inprogress' => t('blacklight.search.bookmarks.inprogress')) do %>
-            <label for=<%= "bookmark_toggle_#{document.id.to_s.parameterize}" %> class="bookmark_remove_label"><h4><span class="glyphicon glyphicon-bookmark"></span></h4></label>
         <%= submit_tag(t('blacklight.bookmarks.remove.button'), :id => "bookmark_toggle_#{document.id.to_s.parameterize}", :class => "bookmark_remove btn btn-default") %>
 
       <% end %>

--- a/app/views/catalog/_search_type_facets.html.erb
+++ b/app/views/catalog/_search_type_facets.html.erb
@@ -2,7 +2,7 @@
   <div class="collapsed collapse-toggle panel-heading" data-toggle="collapse" data-target="#search_type_facets">
     <h5 class="panel-title facet-field-heading">
 
-      <%= link_to t('blacklight.search.facets.refine'), "#", :"data-no-turbolink" => true %>
+      <%= link_to t('blacklight.search.facets.refine'), "#" %>
     </h5>
   </div>
   <div id="search_type_facets" class="panel-collapse facet-content collapse">

--- a/app/views/catalog/facsimile.html.erb
+++ b/app/views/catalog/facsimile.html.erb
@@ -21,7 +21,7 @@
                       </li>
                       <li role="presentation" class="active">
                         <%# Note we need to use no_turbolink because turbolinks will fuck with the unveil library %>
-                        <%= link_to(facsimile_catalog_path(document.id) + "/", data: { no_turbolink: true }) do %>
+                        <%= link_to(facsimile_catalog_path(document.id) + "/") do %>
                             <%= bootstrap_glyphicon 'book' %>
                             Faksimile
                         <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,8 +2,8 @@
 <html>
 <head>
   <title>Adl</title>
-  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-  <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
+  <%= stylesheet_link_tag    'application', media: 'all'%>
+  <%= javascript_include_tag 'application'%>
   <%= csrf_meta_tags %>
 </head>
 <body>


### PR DESCRIPTION
It turns out that turbolink is messing up the bookmark functionallity amongst other. So i removed it. It seem that we were using it in the previous version, because we were putting all facsimile on one page. This has now been replaced by the open seadragon
